### PR TITLE
feat: 大カテゴリ & サブカテゴリ対応の3層構造実装

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,27 +7,38 @@ with open("commands.json", encoding="utf-8") as f:
 
 st.title("🛠️ コマンドリファレンス")
 
-# カテゴリを抽出（重複なし、ソート済み）
-categories = sorted(set(cmd["category"] for cmd in commands))
+# 大カテゴリを抽出（重複なし、ソート済み）
+main_categories = sorted(set(cmd["main_category"] for cmd in commands))
 
-# カテゴリ選択
-selected_category = st.selectbox("📁 カテゴリを選択", categories)
+# 大カテゴリ選択
+selected_main_category = st.selectbox("🏢 大カテゴリを選択", main_categories)
+
+# 選択された大カテゴリのサブカテゴリを抽出
+sub_categories = sorted(set(cmd["sub_category"] for cmd in commands if cmd["main_category"] == selected_main_category))
+
+# サブカテゴリ選択
+selected_sub_category = st.selectbox("📁 サブカテゴリを選択", sub_categories)
 
 # 選択されたカテゴリのコマンドをフィルタリング
-filtered_commands = [cmd for cmd in commands if cmd["category"] == selected_category]
+filtered_commands = [cmd for cmd in commands 
+                    if cmd["main_category"] == selected_main_category 
+                    and cmd["sub_category"] == selected_sub_category]
 command_names = [cmd["name"] for cmd in filtered_commands]
 
 # コマンド選択
-selected_command = st.selectbox("🔧 コマンドを選択", command_names)
-
-# 選択されたコマンドの詳細を取得
-cmd = next(c for c in filtered_commands if c["name"] == selected_command)
-
-st.subheader("📄 説明")
-st.write(cmd["description"])
-
-st.subheader("💻 使用例")
-st.code(cmd["usage"], language="bash")
+if command_names:
+    selected_command = st.selectbox("🔧 コマンドを選択", command_names)
+    
+    # 選択されたコマンドの詳細を取得
+    cmd = next(c for c in filtered_commands if c["name"] == selected_command)
+    
+    st.subheader("📄 説明")
+    st.write(cmd["description"])
+    
+    st.subheader("💻 使用例")
+    st.code(cmd["usage"], language="bash")
+else:
+    st.info("このカテゴリにはコマンドがありません。")
 
 # コマンドビルダーセクション
 st.markdown("---")
@@ -35,116 +46,127 @@ st.title("🛠️ コマンドビルダー")
 
 # ビルダー対応コマンドのみフィルタリング
 builder_commands = [cmd for cmd in commands if "builder" in cmd]
-builder_categories = sorted(set(cmd["category"] for cmd in builder_commands))
+builder_main_categories = sorted(set(cmd["main_category"] for cmd in builder_commands))
 
 if builder_commands:
-    # カテゴリ選択（ビルダー用）
-    builder_category = st.selectbox("📁 ビルダー対応カテゴリを選択", builder_categories, key="builder_category")
+    # 大カテゴリ選択（ビルダー用）
+    builder_main_category = st.selectbox("🏢 ビルダー対応大カテゴリを選択", builder_main_categories, key="builder_main_category")
+    
+    # サブカテゴリを抽出（ビルダー用）
+    builder_sub_categories = sorted(set(cmd["sub_category"] for cmd in builder_commands if cmd["main_category"] == builder_main_category))
+    
+    # サブカテゴリ選択（ビルダー用）
+    builder_sub_category = st.selectbox("📁 ビルダー対応サブカテゴリを選択", builder_sub_categories, key="builder_sub_category")
     
     # 選択されたカテゴリのビルダー対応コマンドをフィルタリング
-    filtered_builder_commands = [cmd for cmd in builder_commands if cmd["category"] == builder_category]
+    filtered_builder_commands = [cmd for cmd in builder_commands 
+                                if cmd["main_category"] == builder_main_category 
+                                and cmd["sub_category"] == builder_sub_category]
     builder_command_names = [cmd["name"] for cmd in filtered_builder_commands]
     
-    # コマンド選択（ビルダー用）
-    selected_builder_command = st.selectbox("🔧 ビルダー対応コマンドを選択", builder_command_names, key="builder_command")
-    
-    # 選択されたコマンドの詳細を取得
-    builder_cmd = next(c for c in filtered_builder_commands if c["name"] == selected_builder_command)
-    
-    st.info(f"📝 {builder_cmd['description']}")
-    
-    # コマンドビルダー
-    if "builder" in builder_cmd:
-        builder = builder_cmd["builder"]
+    if builder_command_names:
+        # コマンド選択（ビルダー用）
+        selected_builder_command = st.selectbox("🔧 ビルダー対応コマンドを選択", builder_command_names, key="builder_command")
         
-        # パラメータ入力
-        param_values = {}
-        if builder.get("params"):
-            st.subheader("📥 必須パラメータ")
-            for param in builder["params"]:
-                # パラメータ名を日本語に変換
-                param_label = {
-                    "path": "パス",
-                    "source": "ソース",
-                    "destination": "宛先",
-                    "function-name": "関数名",
-                    "output-file": "出力ファイル",
-                    "repository-url": "リポジトリURL",
-                    "directory": "ディレクトリ"
-                }.get(param, param)
-                
-                param_values[param] = st.text_input(f"{param_label}", key=f"param_{param}")
+        # 選択されたコマンドの詳細を取得
+        builder_cmd = next(c for c in filtered_builder_commands if c["name"] == selected_builder_command)
         
-        # オプション選択
-        option_values = []
-        if builder.get("options"):
-            st.subheader("⚙️ オプション")
+        st.info(f"📝 {builder_cmd['description']}")
+        
+        # コマンドビルダー
+        if "builder" in builder_cmd:
+            builder = builder_cmd["builder"]
             
-            for opt in builder["options"]:
-                col1, col2 = st.columns([1, 3])
-                
-                with col1:
-                    st.write(opt["name"])
-                
-                with col2:
-                    if opt["type"] == "flag":
-                        if st.checkbox(opt["description"], key=f"opt_{opt['name']}"):
-                            option_values.append(opt["name"])
+            # パラメータ入力
+            param_values = {}
+            if builder.get("params"):
+                st.subheader("📥 必須パラメータ")
+                for param in builder["params"]:
+                    # パラメータ名を日本語に変換
+                    param_label = {
+                        "path": "パス",
+                        "source": "ソース",
+                        "destination": "宛先",
+                        "function-name": "関数名",
+                        "output-file": "出力ファイル",
+                        "repository-url": "リポジトリURL",
+                        "directory": "ディレクトリ"
+                    }.get(param, param)
                     
-                    elif opt["type"] == "text":
-                        val = st.text_input(
-                            opt["description"],
-                            key=f"opt_{opt['name']}_text"
-                        )
-                        if val:
-                            option_values.append(f"{opt['name']} {val}")
+                    param_values[param] = st.text_input(f"{param_label}", key=f"param_{param}")
+            
+            # オプション選択
+            option_values = []
+            if builder.get("options"):
+                st.subheader("⚙️ オプション")
+                
+                for opt in builder["options"]:
+                    col1, col2 = st.columns([1, 3])
                     
-                    elif opt["type"] == "select":
-                        val = st.selectbox(
-                            opt["description"],
-                            ["選択してください"] + opt["choices"],
-                            key=f"opt_{opt['name']}_select"
-                        )
-                        if val != "選択してください":
-                            option_values.append(f"{opt['name']}{val}")
-        
-        # コマンド生成
-        st.subheader("✨ 生成されたコマンド")
-        
-        # コマンドを組み立て
-        cmd_parts = [selected_builder_command]
-        
-        # パラメータを追加
-        for param in builder.get("params", []):
-            if param in param_values and param_values[param]:
-                # aws lambda invokeの場合、--function-nameを追加
-                if selected_builder_command == "aws lambda invoke" and param == "function-name":
-                    cmd_parts.append(f"--function-name {param_values[param]}")
-                # git cloneの場合、repository-urlとdirectoryは位置引数
-                elif selected_builder_command == "git clone":
-                    cmd_parts.append(param_values[param])
-                else:
-                    cmd_parts.append(param_values[param])
-        
-        # オプションを追加
-        cmd_parts.extend(option_values)
-        
-        final_command = " ".join(cmd_parts)
-        
-        # コマンド表示とコピー機能
-        col1, col2 = st.columns([5, 1])
-        
-        with col1:
-            st.code(final_command, language="bash")
-        
-        with col2:
-            # Streamlitのデフォルトのコピー機能を使用するため、
-            # 説明テキストのみ表示
-            st.write("")
-            st.caption("📋 コピー")
-        
-        # 使用例
-        if final_command.strip() and final_command != selected_builder_command:
-            st.success("✅ コマンドが生成されました！上記のコマンドをコピーして使用してください。")
+                    with col1:
+                        st.write(opt["name"])
+                    
+                    with col2:
+                        if opt["type"] == "flag":
+                            if st.checkbox(opt["description"], key=f"opt_{opt['name']}"):
+                                option_values.append(opt["name"])
+                        
+                        elif opt["type"] == "text":
+                            val = st.text_input(
+                                opt["description"],
+                                key=f"opt_{opt['name']}_text"
+                            )
+                            if val:
+                                option_values.append(f"{opt['name']} {val}")
+                        
+                        elif opt["type"] == "select":
+                            val = st.selectbox(
+                                opt["description"],
+                                ["選択してください"] + opt["choices"],
+                                key=f"opt_{opt['name']}_select"
+                            )
+                            if val != "選択してください":
+                                option_values.append(f"{opt['name']}{val}")
+            
+            # コマンド生成
+            st.subheader("✨ 生成されたコマンド")
+            
+            # コマンドを組み立て
+            cmd_parts = [selected_builder_command]
+            
+            # パラメータを追加
+            for param in builder.get("params", []):
+                if param in param_values and param_values[param]:
+                    # aws lambda invokeの場合、--function-nameを追加
+                    if selected_builder_command == "aws lambda invoke" and param == "function-name":
+                        cmd_parts.append(f"--function-name {param_values[param]}")
+                    # git cloneの場合、repository-urlとdirectoryは位置引数
+                    elif selected_builder_command == "git clone":
+                        cmd_parts.append(param_values[param])
+                    else:
+                        cmd_parts.append(param_values[param])
+            
+            # オプションを追加
+            cmd_parts.extend(option_values)
+            
+            final_command = " ".join(cmd_parts)
+            
+            # コマンド表示とコピー機能
+            col1, col2 = st.columns([5, 1])
+            
+            with col1:
+                st.code(final_command, language="bash")
+            
+            with col2:
+                # Streamlitのデフォルトのコピー機能を使用するため、
+                # 説明テキストのみ表示
+                st.write("")
+                st.caption("📋 コピー")
+            
+            # 使用例
+            if final_command.strip() and final_command != selected_builder_command:
+                st.success("✅ コマンドが生成されました！上記のコマンドをコピーして使用してください。")
+    else:
+        st.info("このカテゴリにはビルダー対応コマンドがありません。")
 else:
     st.info("現在、コマンドビルダーに対応したコマンドはありません。")

--- a/commands_backup_20250629.json
+++ b/commands_backup_20250629.json
@@ -1,7 +1,6 @@
 [
   {
-    "main_category": "Linux",
-    "sub_category": "基本操作",
+    "category": "Linux",
     "name": "ls",
     "description": "ディレクトリの内容を一覧表示します。",
     "usage": "ls [オプション] [ファイル]",
@@ -18,36 +17,31 @@
     }
   },
   {
-    "main_category": "Linux",
-    "sub_category": "基本操作",
+    "category": "Linux",
     "name": "cd",
     "description": "カレントディレクトリを変更します。",
     "usage": "cd ディレクトリ"
   },
   {
-    "main_category": "Linux",
-    "sub_category": "基本操作",
+    "category": "Linux",
     "name": "pwd",
     "description": "現在の作業ディレクトリを表示します。",
     "usage": "pwd"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Core",
+    "category": "AWS Core",
     "name": "aws configure",
     "description": "AWS CLIの認証情報とデフォルト設定を構成します。",
     "usage": "aws configure [--profile プロファイル名]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "S3",
+    "category": "AWS S3",
     "name": "aws s3 ls",
     "description": "S3バケットまたはオブジェクトを一覧表示します。",
     "usage": "aws s3 ls [s3://バケット名/パス]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "S3",
+    "category": "AWS S3",
     "name": "aws s3 cp",
     "description": "ファイルをS3にコピーまたはS3からコピーします。",
     "usage": "aws s3 cp ソース 宛先 [--recursive]",
@@ -64,36 +58,31 @@
     }
   },
   {
-    "main_category": "AWS",
-    "sub_category": "S3",
+    "category": "AWS S3",
     "name": "aws s3 sync",
     "description": "ディレクトリとS3バケットを同期します。",
     "usage": "aws s3 sync ソース 宛先 [--delete]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "S3",
+    "category": "AWS S3",
     "name": "aws s3 rm",
     "description": "S3オブジェクトを削除します。",
     "usage": "aws s3 rm s3://バケット名/オブジェクト [--recursive]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "S3",
+    "category": "AWS S3",
     "name": "aws s3 mb",
     "description": "S3バケットを作成します。",
     "usage": "aws s3 mb s3://バケット名"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "S3",
+    "category": "AWS S3",
     "name": "aws s3 rb",
     "description": "S3バケットを削除します。",
     "usage": "aws s3 rb s3://バケット名 [--force]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "EC2",
+    "category": "AWS EC2",
     "name": "aws ec2 describe-instances",
     "description": "EC2インスタンスの情報を表示します。",
     "usage": "aws ec2 describe-instances [--instance-ids i-xxxxx]",
@@ -109,71 +98,61 @@
     }
   },
   {
-    "main_category": "AWS",
-    "sub_category": "EC2",
+    "category": "AWS EC2",
     "name": "aws ec2 start-instances",
     "description": "停止中のEC2インスタンスを起動します。",
     "usage": "aws ec2 start-instances --instance-ids i-xxxxx"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "EC2",
+    "category": "AWS EC2",
     "name": "aws ec2 stop-instances",
     "description": "実行中のEC2インスタンスを停止します。",
     "usage": "aws ec2 stop-instances --instance-ids i-xxxxx"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "EC2",
+    "category": "AWS EC2",
     "name": "aws ec2 reboot-instances",
     "description": "EC2インスタンスを再起動します。",
     "usage": "aws ec2 reboot-instances --instance-ids i-xxxxx"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "EC2",
+    "category": "AWS EC2",
     "name": "aws ec2 terminate-instances",
     "description": "EC2インスタンスを終了（削除）します。",
     "usage": "aws ec2 terminate-instances --instance-ids i-xxxxx"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "EC2",
+    "category": "AWS EC2",
     "name": "aws ec2 describe-images",
     "description": "利用可能なAMIを表示します。",
     "usage": "aws ec2 describe-images --owners self amazon"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "EC2",
+    "category": "AWS EC2",
     "name": "aws ec2 describe-security-groups",
     "description": "セキュリティグループの情報を表示します。",
     "usage": "aws ec2 describe-security-groups [--group-ids sg-xxxxx]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "EC2",
+    "category": "AWS EC2",
     "name": "aws ec2 describe-vpcs",
     "description": "VPCの情報を表示します。",
     "usage": "aws ec2 describe-vpcs [--vpc-ids vpc-xxxxx]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "EC2",
+    "category": "AWS EC2",
     "name": "aws ec2 describe-subnets",
     "description": "サブネットの情報を表示します。",
     "usage": "aws ec2 describe-subnets [--subnet-ids subnet-xxxxx]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Lambda",
+    "category": "AWS Lambda",
     "name": "aws lambda list-functions",
     "description": "Lambda関数の一覧を表示します。",
     "usage": "aws lambda list-functions [--region リージョン]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Lambda",
+    "category": "AWS Lambda",
     "name": "aws lambda invoke",
     "description": "Lambda関数を実行します。",
     "usage": "aws lambda invoke --function-name 関数名 出力ファイル",
@@ -189,274 +168,235 @@
     }
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Lambda",
+    "category": "AWS Lambda",
     "name": "aws lambda create-function",
     "description": "新しいLambda関数を作成します。",
     "usage": "aws lambda create-function --function-name 名前 --runtime ランタイム --role ARN --handler ハンドラ --zip-file fileb://ファイル.zip"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Lambda",
+    "category": "AWS Lambda",
     "name": "aws lambda update-function-code",
     "description": "Lambda関数のコードを更新します。",
     "usage": "aws lambda update-function-code --function-name 関数名 --zip-file fileb://ファイル.zip"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Lambda",
+    "category": "AWS Lambda",
     "name": "aws lambda delete-function",
     "description": "Lambda関数を削除します。",
     "usage": "aws lambda delete-function --function-name 関数名"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "IAM",
+    "category": "AWS IAM",
     "name": "aws iam list-users",
     "description": "IAMユーザーの一覧を表示します。",
     "usage": "aws iam list-users"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "IAM",
+    "category": "AWS IAM",
     "name": "aws iam create-user",
     "description": "新しいIAMユーザーを作成します。",
     "usage": "aws iam create-user --user-name ユーザー名"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "IAM",
+    "category": "AWS IAM",
     "name": "aws iam delete-user",
     "description": "IAMユーザーを削除します。",
     "usage": "aws iam delete-user --user-name ユーザー名"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "IAM",
+    "category": "AWS IAM",
     "name": "aws iam list-roles",
     "description": "IAMロールの一覧を表示します。",
     "usage": "aws iam list-roles"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "IAM",
+    "category": "AWS IAM",
     "name": "aws iam attach-user-policy",
     "description": "ユーザーにポリシーをアタッチします。",
     "usage": "aws iam attach-user-policy --user-name ユーザー名 --policy-arn ポリシーARN"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "RDS",
+    "category": "AWS RDS",
     "name": "aws rds describe-db-instances",
     "description": "RDSインスタンスの情報を表示します。",
     "usage": "aws rds describe-db-instances [--db-instance-identifier ID]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "RDS",
+    "category": "AWS RDS",
     "name": "aws rds create-db-instance",
     "description": "新しいRDSインスタンスを作成します。",
     "usage": "aws rds create-db-instance --db-instance-identifier ID --db-instance-class クラス --engine エンジン --master-username ユーザー --master-user-password パスワード"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "RDS",
+    "category": "AWS RDS",
     "name": "aws rds delete-db-instance",
     "description": "RDSインスタンスを削除します。",
     "usage": "aws rds delete-db-instance --db-instance-identifier ID --skip-final-snapshot"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "CloudFormation",
+    "category": "AWS CloudFormation",
     "name": "aws cloudformation list-stacks",
     "description": "CloudFormationスタックの一覧を表示します。",
     "usage": "aws cloudformation list-stacks [--stack-status-filter CREATE_COMPLETE]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "CloudFormation",
+    "category": "AWS CloudFormation",
     "name": "aws cloudformation create-stack",
     "description": "新しいCloudFormationスタックを作成します。",
     "usage": "aws cloudformation create-stack --stack-name 名前 --template-body file://テンプレート.yaml"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "CloudFormation",
+    "category": "AWS CloudFormation",
     "name": "aws cloudformation update-stack",
     "description": "CloudFormationスタックを更新します。",
     "usage": "aws cloudformation update-stack --stack-name 名前 --template-body file://テンプレート.yaml"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "CloudFormation",
+    "category": "AWS CloudFormation",
     "name": "aws cloudformation delete-stack",
     "description": "CloudFormationスタックを削除します。",
     "usage": "aws cloudformation delete-stack --stack-name 名前"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "CloudFormation",
+    "category": "AWS CloudFormation",
     "name": "aws cloudformation describe-stacks",
     "description": "スタックの詳細情報を表示します。",
     "usage": "aws cloudformation describe-stacks --stack-name 名前"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "DynamoDB",
+    "category": "AWS DynamoDB",
     "name": "aws dynamodb list-tables",
     "description": "DynamoDBテーブルの一覧を表示します。",
     "usage": "aws dynamodb list-tables"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "DynamoDB",
+    "category": "AWS DynamoDB",
     "name": "aws dynamodb describe-table",
     "description": "DynamoDBテーブルの詳細を表示します。",
     "usage": "aws dynamodb describe-table --table-name テーブル名"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "DynamoDB",
+    "category": "AWS DynamoDB",
     "name": "aws dynamodb scan",
     "description": "DynamoDBテーブルをスキャンします。",
     "usage": "aws dynamodb scan --table-name テーブル名"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "DynamoDB",
+    "category": "AWS DynamoDB",
     "name": "aws dynamodb put-item",
     "description": "DynamoDBテーブルにアイテムを追加します。",
     "usage": "aws dynamodb put-item --table-name テーブル名 --item '{\"key\": {\"S\": \"value\"}}'"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Messaging",
+    "category": "AWS Messaging",
     "name": "aws sqs list-queues",
     "description": "SQSキューの一覧を表示します。",
     "usage": "aws sqs list-queues"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Messaging",
+    "category": "AWS Messaging",
     "name": "aws sqs send-message",
     "description": "SQSキューにメッセージを送信します。",
     "usage": "aws sqs send-message --queue-url URL --message-body \"メッセージ\""
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Messaging",
+    "category": "AWS Messaging",
     "name": "aws sqs receive-message",
     "description": "SQSキューからメッセージを受信します。",
     "usage": "aws sqs receive-message --queue-url URL"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Messaging",
+    "category": "AWS Messaging",
     "name": "aws sns list-topics",
     "description": "SNSトピックの一覧を表示します。",
     "usage": "aws sns list-topics"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Messaging",
+    "category": "AWS Messaging",
     "name": "aws sns publish",
     "description": "SNSトピックにメッセージを発行します。",
     "usage": "aws sns publish --topic-arn ARN --message \"メッセージ\""
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Monitoring",
+    "category": "AWS Monitoring",
     "name": "aws cloudwatch describe-alarms",
     "description": "CloudWatchアラームの一覧を表示します。",
     "usage": "aws cloudwatch describe-alarms [--alarm-names アラーム名]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Monitoring",
+    "category": "AWS Monitoring",
     "name": "aws logs describe-log-groups",
     "description": "CloudWatch Logsのロググループを表示します。",
     "usage": "aws logs describe-log-groups"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Monitoring",
+    "category": "AWS Monitoring",
     "name": "aws logs tail",
     "description": "CloudWatch Logsのログをリアルタイムで表示します。",
     "usage": "aws logs tail ロググループ名 [--follow]"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Container",
+    "category": "AWS Container",
     "name": "aws ecr get-login-password",
     "description": "ECRレジストリにログインするためのパスワードを取得します。",
     "usage": "aws ecr get-login-password --region リージョン | docker login --username AWS --password-stdin レジストリURL"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Container",
+    "category": "AWS Container",
     "name": "aws ecr list-images",
     "description": "ECRリポジトリ内のイメージを一覧表示します。",
     "usage": "aws ecr list-images --repository-name リポジトリ名"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Container",
+    "category": "AWS Container",
     "name": "aws eks list-clusters",
     "description": "EKSクラスターの一覧を表示します。",
     "usage": "aws eks list-clusters"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Container",
+    "category": "AWS Container",
     "name": "aws eks update-kubeconfig",
     "description": "kubeconfigファイルをEKSクラスター用に更新します。",
     "usage": "aws eks update-kubeconfig --name クラスター名"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Networking",
+    "category": "AWS Networking",
     "name": "aws route53 list-hosted-zones",
     "description": "Route 53のホストゾーンを一覧表示します。",
     "usage": "aws route53 list-hosted-zones"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Networking",
+    "category": "AWS Networking",
     "name": "aws apigateway get-rest-apis",
     "description": "API GatewayのREST APIを一覧表示します。",
     "usage": "aws apigateway get-rest-apis"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Core",
+    "category": "AWS Core",
     "name": "aws sts get-caller-identity",
     "description": "現在の認証情報の詳細を表示します。",
     "usage": "aws sts get-caller-identity"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Core",
+    "category": "AWS Core",
     "name": "aws sts assume-role",
     "description": "IAMロールを引き受けて一時的な認証情報を取得します。",
     "usage": "aws sts assume-role --role-arn ロールARN --role-session-name セッション名"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Management",
+    "category": "AWS Management",
     "name": "aws organizations list-accounts",
     "description": "AWS Organizations内のアカウントを一覧表示します。",
     "usage": "aws organizations list-accounts"
   },
   {
-    "main_category": "AWS",
-    "sub_category": "Management",
+    "category": "AWS Management",
     "name": "aws cost-explorer get-cost-and-usage",
     "description": "AWSの利用料金とコストを取得します。",
     "usage": "aws ce get-cost-and-usage --time-period Start=YYYY-MM-DD,End=YYYY-MM-DD --granularity DAILY --metrics UnblendedCost"
   },
   {
-    "main_category": "Git",
-    "sub_category": "バージョン管理",
+    "category": "Git",
     "name": "git log",
     "description": "コミット履歴を表示します。",
     "usage": "git log [オプション]",
@@ -475,8 +415,7 @@
     }
   },
   {
-    "main_category": "Git",
-    "sub_category": "バージョン管理",
+    "category": "Git",
     "name": "git clone",
     "description": "リポジトリをクローンします。",
     "usage": "git clone [オプション] リポジトリURL [ディレクトリ]",


### PR DESCRIPTION
## Summary

- コマンドリファレンスに3層カテゴリ構造を実装
- 大カテゴリ → サブカテゴリ → コマンドの階層構造で整理
- JSONデータ構造を`main_category`と`sub_category`に変更

Closes #13

メリット:
- 大量のAWSサービスが整理され、ナビゲーションが容易に
- ユーザーが目的のコマンドを見つけやすくなる
- 将来的に新しい大カテゴリ（Python、Bashなど）を追加しやすい

## Test plan

- [ ] `streamlit run app.py`でアプリ起動
- [ ] 大カテゴリで"AWS"を選択
- [ ] サブカテゴリが正しく表示されることを確認
- [ ] コマンドが正しくフィルタリングされることを確認
- [ ] コマンドビルダーも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)